### PR TITLE
Yandex loading issue (#81)

### DIFF
--- a/src/content/bot/YandexBot.js
+++ b/src/content/bot/YandexBot.js
@@ -48,6 +48,7 @@ export default class YandexBot extends Bot{
     } else {
       setTimeout(async function(){
         await this.scroll_down()
+        this.get_more_videos_button()?.click()
         this.videos_animation(0);
       }.bind(this), this.initial_scroll_delay + extra_delay);
     }
@@ -68,7 +69,7 @@ export default class YandexBot extends Bot{
 
 
   get_more_videos_button(){
-    return document.querySelector('div.more_last_yes button');
+    return document.querySelector('button.NextPageButton_direction_next');
   }
 
   get_search_input(){

--- a/src/content/bot/YandexBot.js
+++ b/src/content/bot/YandexBot.js
@@ -54,6 +54,13 @@ export default class YandexBot extends Bot{
     }
   }
 
+  set_get_next_button_text_result_timeout(){
+    setTimeout(() => {
+      const button = this.get_next_button();
+      if (button) { location.assign(button.href);}
+      else { this.jump_to_next_active_result_type('Text', null, ['News']);}
+    }, this.next_delay);
+  }
 
   set_videos_results_animation(callback_end){
     setTimeout(function(){


### PR DESCRIPTION
Fixes the Yandex text pagination and load more (#81).

- Yandex changes the results without loading a new page when WebBot clicks the Next button for the first time, so WebBot now opens the Next link directly.
- Clicks Yandex's Video "More videos" button to load more results.